### PR TITLE
feat: data layer for collections and stockists

### DIFF
--- a/src/lib/data/collections.ts
+++ b/src/lib/data/collections.ts
@@ -1,0 +1,67 @@
+export type HexColor = `#${string}`;
+
+export type Product = {
+	name: string;
+	price: string;
+	colors: [HexColor, HexColor, HexColor];
+};
+
+export type Collection = {
+	id: string;
+	name: string;
+	sub: string;
+	color: HexColor;
+	bg: `var(--${string})`;
+	products: [Product, Product, Product];
+};
+
+export const collections = [
+	{
+		id: 'soleil',
+		name: 'Soleil',
+		sub: 'Warm tones, gathered at noon.',
+		color: '#C17B3A',
+		bg: 'var(--soleil-bg)',
+		products: [
+			{ name: 'Abricot', price: '$0.50', colors: ['#C17B3A', '#E0A26A', '#F2D7AB'] },
+			{ name: 'Miel', price: '$0.50', colors: ['#9C5E29', '#D89351', '#EFC084'] },
+			{ name: 'Curcuma', price: '$0.50', colors: ['#B6692C', '#E89B47', '#F4D08A'] }
+		]
+	},
+	{
+		id: 'foret',
+		name: 'Forêt',
+		sub: 'The hush of leaves after rain.',
+		color: '#4A8B7A',
+		bg: 'var(--foret-bg)',
+		products: [
+			{ name: 'Mousse', price: '$0.50', colors: ['#4A8B7A', '#7CB0A1', '#B5D4C9'] },
+			{ name: 'Sauge', price: '$0.50', colors: ['#3F7568', '#6FA192', '#A9C7BC'] },
+			{ name: 'Eucalypt', price: '$0.50', colors: ['#5A9A87', '#8FB9AC', '#C2DACF'] }
+		]
+	},
+	{
+		id: 'crepuscule',
+		name: 'Crépuscule',
+		sub: 'The hour before the lamps come on.',
+		color: '#7B6AAF',
+		bg: 'var(--crepuscule-bg)',
+		products: [
+			{ name: 'Iris', price: '$0.50', colors: ['#7B6AAF', '#A092C5', '#CCC2DD'] },
+			{ name: 'Lavande', price: '$0.50', colors: ['#6C5C9F', '#9286BC', '#C0B6D6'] },
+			{ name: 'Brume', price: '$0.50', colors: ['#8A7CB9', '#B0A6CD', '#D8D1E4'] }
+		]
+	},
+	{
+		id: 'rose',
+		name: 'Rosé',
+		sub: 'A blush, considered.',
+		color: '#D4537E',
+		bg: 'var(--rose-bg)',
+		products: [
+			{ name: 'Pivoine', price: '$0.50', colors: ['#D4537E', '#E489A5', '#F2BFCE'] },
+			{ name: 'Cerise', price: '$0.50', colors: ['#C04270', '#DA7A98', '#EDB1C2'] },
+			{ name: 'Aurore', price: '$0.50', colors: ['#DD6B92', '#EE9CB7', '#F8CDD7'] }
+		]
+	}
+] as const satisfies [Collection, ...Collection[]];

--- a/src/lib/data/stockists.ts
+++ b/src/lib/data/stockists.ts
@@ -1,0 +1,20 @@
+export type StockistStatus = 'in-stock' | 'sold-out';
+
+export type Stockist = {
+	city: string;
+	place: string;
+	country: string;
+	x: number;
+	y: number;
+	status: StockistStatus;
+};
+
+export const stockists = [
+	{ city: 'Stayner', place: 'Evangelical Camp — Scott St', country: 'CA', x: 200, y: 245, status: 'in-stock' },
+	{ city: 'London', place: 'Liberty — Carnaby', country: 'UK', x: 470, y: 188, status: 'sold-out' },
+	{ city: 'New York', place: 'Bergdorf Goodman — 5th Ave', country: 'US', x: 230, y: 260, status: 'sold-out' },
+	{ city: 'Paris', place: 'Le Bon Marché — Rive Gauche', country: 'FR', x: 510, y: 220, status: 'sold-out' },
+	{ city: 'Tokyo', place: 'Isetan — Shinjuku', country: 'JP', x: 870, y: 270, status: 'sold-out' },
+	{ city: 'Copenhagen', place: 'Stilleben — Frederiksberggade', country: 'DK', x: 545, y: 168, status: 'sold-out' },
+	{ city: 'Melbourne', place: 'Craft Victoria', country: 'AU', x: 855, y: 470, status: 'sold-out' }
+] as const satisfies [Stockist, ...Stockist[]];


### PR DESCRIPTION
## Summary

- Implements **#3** — typed TypeScript data modules sourced from `landing.html`
- `src/lib/data/collections.ts` — `const satisfies` array of 4 collections (Soleil, Forêt, Crépuscule, Rosé), each with 3 product cards and 3 hex color values for the Bracelet component
- `src/lib/data/stockists.ts` — `const satisfies` array of 7 stockist cities with map coordinates and in-stock/sold-out state
- Pure static data, no runtime logic, no `any` types
- Adding a stockist or product is a one-line edit

## Acceptance criteria

- [x] `src/lib/data/collections.ts` exports a typed const array with all four collections
- [x] Each collection entry includes name, three product cards, and three bracelet hex color values
- [x] `src/lib/data/stockists.ts` exports a typed const array with all seven stockist cities
- [x] Each stockist entry includes city name, map pin coordinates, and stock state
- [x] Both modules use TypeScript types (not `any`)
- [x] Data matches `landing.html` source definitions
- [x] Adding a stockist or product is a one-line edit

Closes #3