### PR TITLE
feat: atom components + Bracelet

### DIFF
--- a/src/lib/components/atoms/Bracelet.svelte
+++ b/src/lib/components/atoms/Bracelet.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import type { HexColor } from '$lib/data/collections';
+
+	type BraceletStyle = 'ellipse' | 'woven';
+
+	let {
+		colors,
+		style = 'ellipse',
+		rotation = -8
+	}: {
+		colors: [HexColor, HexColor, HexColor];
+		style?: BraceletStyle;
+		rotation?: number;
+	} = $props();
+
+	const cx = 140;
+	const cy = 80;
+	const rx = 110;
+	const ry = 52;
+</script>
+
+<svg viewBox="0 0 280 160" class="block h-full w-full" preserveAspectRatio="xMidYMid meet">
+	<g transform="rotate({rotation} {cx} {cy})">
+		{#if style === 'ellipse'}
+			<ellipse
+				{cx}
+				{cy}
+				rx={rx + 6}
+				ry={ry + 6}
+				fill="none"
+				stroke={colors[0]}
+				stroke-opacity="0.08"
+				stroke-width="1"
+			/>
+			<ellipse
+				{cx}
+				{cy}
+				{rx}
+				{ry}
+				fill="none"
+				stroke={colors[0]}
+				stroke-width="6"
+				stroke-linecap="round"
+			/>
+			<ellipse
+				{cx}
+				{cy}
+				rx={rx - 5}
+				ry={ry - 5}
+				fill="none"
+				stroke={colors[1]}
+				stroke-width="1.6"
+				stroke-dasharray="3 3"
+				opacity="0.7"
+			/>
+			<ellipse
+				{cx}
+				{cy}
+				rx={rx - 14}
+				ry={ry - 14}
+				fill="none"
+				stroke={colors[2]}
+				stroke-width="1"
+				opacity="0.4"
+			/>
+		{:else}
+			<ellipse
+				{cx}
+				{cy}
+				{rx}
+				{ry}
+				fill="none"
+				stroke={colors[0]}
+				stroke-opacity="0.14"
+				stroke-width="0.6"
+			/>
+			{#each Array(36) as _, i (i)}
+				{@const t = (i / 36) * Math.PI * 2}
+				<circle
+					cx={cx + Math.cos(t) * (rx - 12)}
+					cy={cy + Math.sin(t) * (ry - 12)}
+					r="1"
+					fill={colors[2]}
+					opacity="0.5"
+				/>
+			{/each}
+			{#each Array(56) as _, i (i)}
+				{@const t = (i / 56) * Math.PI * 2}
+				{@const col = i % 3 === 0 ? colors[0] : i % 3 === 1 ? colors[1] : colors[2]}
+				{@const r = i % 3 === 0 ? 3.4 : 2.6}
+				<circle
+					cx={cx + Math.cos(t) * rx}
+					cy={cy + Math.sin(t) * ry}
+					{r}
+					fill={col}
+					opacity={i % 3 === 0 ? 1 : 0.85}
+				/>
+			{/each}
+		{/if}
+	</g>
+</svg>

--- a/src/lib/components/atoms/Button.svelte
+++ b/src/lib/components/atoms/Button.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+
+	type Variant = 'primary' | 'ghost';
+
+	let {
+		variant = 'ghost',
+		children,
+		...rest
+	}: HTMLButtonAttributes & {
+		variant?: Variant;
+		children?: Snippet;
+	} = $props();
+</script>
+
+<button
+	class="inline-flex items-center gap-2 rounded-full border-[0.5px] px-[18px] py-3 font-sans
+	       text-[11px] font-medium tracking-[0.2em] uppercase transition-all duration-250 ease-out
+	       {variant === 'primary'
+		? 'border-amber bg-amber text-white hover:border-amber/85 hover:bg-amber/85'
+		: 'border-hairline bg-transparent text-text-primary hover:border-amber hover:text-amber'}"
+	{...rest}
+>
+	{#if children}
+		{@render children()}
+	{/if}
+</button>

--- a/src/lib/components/atoms/Eyebrow.svelte
+++ b/src/lib/components/atoms/Eyebrow.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<span class="font-sans text-[9.5px] font-medium tracking-[0.28em] text-amber uppercase">
+	{@render children()}
+</span>

--- a/src/lib/components/atoms/Hairline.svelte
+++ b/src/lib/components/atoms/Hairline.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	let {
+		position = 'bottom',
+		class: className = ''
+	}: { position?: 'top' | 'bottom'; class?: string } = $props();
+
+	let borderClass = $derived(
+		position === 'top' ? 'border-t border-hairline' : 'border-b border-hairline'
+	);
+</script>
+
+<hr class={`border-0 ${borderClass} ${className}`} />

--- a/src/lib/components/atoms/NavMark.svelte
+++ b/src/lib/components/atoms/NavMark.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	let { class: className = '' }: { class?: string } = $props();
+</script>
+
+<div
+	aria-hidden="true"
+	class="grid h-[22px] w-[22px] grid-cols-2 grid-rows-2 gap-[1.5px] overflow-hidden rounded-[4px] {className}"
+>
+	<i class="block rounded-[1.5px] bg-amber"></i>
+	<i class="block rounded-[1.5px] bg-jade"></i>
+	<i class="block rounded-[1.5px] bg-blush"></i>
+	<i class="block rounded-[1.5px] bg-violet"></i>
+</div>

--- a/src/lib/components/atoms/PhotoCorner.svelte
+++ b/src/lib/components/atoms/PhotoCorner.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<span
+	class="absolute top-[14px] right-[14px] font-mono text-[9px] tracking-[0.12em] text-text-tertiary uppercase"
+>
+	{@render children()}
+</span>

--- a/src/lib/components/atoms/PhotoTag.svelte
+++ b/src/lib/components/atoms/PhotoTag.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<span
+	class="absolute bottom-[14px] left-[14px] font-mono text-[9.5px] tracking-[0.08em] text-text-tertiary"
+>
+	{@render children()}
+</span>

--- a/src/lib/components/atoms/SmallCaps.svelte
+++ b/src/lib/components/atoms/SmallCaps.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<span class="font-sans text-[10px] font-medium tracking-[0.18em] uppercase">
+	{@render children()}
+</span>

--- a/src/lib/components/atoms/Swatch.svelte
+++ b/src/lib/components/atoms/Swatch.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { HexColor } from '$lib/data/collections';
+
+	let { color, size = 'sm' }: { color: HexColor; size?: 'sm' | 'md' | 'lg' } = $props();
+
+	let sizeClass = $derived(
+		size === 'sm' ? 'w-[10px] h-[10px]' : size === 'md' ? 'w-3 h-3' : 'w-4 h-4'
+	);
+</script>
+
+<span class="inline-block rounded-full {sizeClass}" style:background-color={color}></span>

--- a/src/lib/components/atoms/Wordmark.svelte
+++ b/src/lib/components/atoms/Wordmark.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { size = 'md' }: { size?: 'sm' | 'md' | 'lg'; children?: Snippet } = $props();
+</script>
+
+<span
+	class="font-display leading-none font-light tracking-[0.02em] italic
+	       {size === 'sm' ? 'text-[28px]' : size === 'lg' ? 'text-[34px]' : 'text-[18px]'}"
+>
+	Hue<span class="font-normal text-amber"> & </span>Weave
+</span>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,0 +1,10 @@
+export { default as Bracelet } from './atoms/Bracelet.svelte';
+export { default as Button } from './atoms/Button.svelte';
+export { default as Eyebrow } from './atoms/Eyebrow.svelte';
+export { default as Hairline } from './atoms/Hairline.svelte';
+export { default as NavMark } from './atoms/NavMark.svelte';
+export { default as PhotoCorner } from './atoms/PhotoCorner.svelte';
+export { default as PhotoTag } from './atoms/PhotoTag.svelte';
+export { default as SmallCaps } from './atoms/SmallCaps.svelte';
+export { default as Swatch } from './atoms/Swatch.svelte';
+export { default as Wordmark } from './atoms/Wordmark.svelte';


### PR DESCRIPTION
## Summary

Closes #4

Implements all nine atom-level components and the Bracelet shared primitive under `src/lib/components/atoms/`, as specified in issue #4.

### Atoms
- **Button** — `primary` / `ghost` variants, accepts all native button attributes
- **Eyebrow** — small-caps accent label in `text-amber`
- **SmallCaps** — uppercase tracking label (neutral color)
- **Wordmark** — "Hue & Weave" italic brand mark with `sm`/`md`/`lg` sizes
- **NavMark** — 2×2 color grid icon (amber, jade, blush, violet)
- **Swatch** — circular color dot with `sm`/`md`/`lg` sizes
- **Hairline** — horizontal rule with `top`/`bottom` position
- **PhotoTag** — absolute-positioned monospace caption (bottom-left)
- **PhotoCorner** — absolute-positioned monospace label (top-right)

### Bracelet
- Props: `colors` (3 hex values), `style` (`'ellipse'` | `'woven'`, defaults to `'ellipse'`), `rotation` (defaults to `-8`)
- Ellipse mode: layered ellipse strokes with halo, dash, and inner depth
- Woven mode: bead-pattern circles on an elliptical path with inner thread dots
- Direct port of the React Bracelet from `landing.html`

### Design constraints met
- All components use Svelte 5 runes (`$props`, `$derived`)
- Semantic Tailwind token utilities only — no raw hex values in component markup
- Barrel export via `src/lib/components/index.ts`
- Passes `svelte-check` (0 errors, 0 warnings) and ESLint

## Acceptance criteria

- [x] All nine non-Bracelet atoms exist under `src/lib/components/atoms/`
- [x] Bracelet component exists under `src/lib/components/atoms/` with `colors`, `style`, and `rotation` props
- [x] Bracelet renders correctly in both `'ellipse'` and `'woven'` modes
- [x] `style` prop defaults to `'ellipse'`
- [x] All atoms use semantic Tailwind token utilities — no raw hex values in component markup
- [x] All components are Svelte 5 runes syntax