### PR TITLE
feat: Nav organism with NavLogo and NavLinks molecules

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -8,3 +8,8 @@ export { default as PhotoTag } from './atoms/PhotoTag.svelte';
 export { default as SmallCaps } from './atoms/SmallCaps.svelte';
 export { default as Swatch } from './atoms/Swatch.svelte';
 export { default as Wordmark } from './atoms/Wordmark.svelte';
+
+export { default as NavLogo } from './molecules/NavLogo.svelte';
+export { default as NavLinks } from './molecules/NavLinks.svelte';
+
+export { default as Nav } from './organisms/Nav.svelte';

--- a/src/lib/components/molecules/NavLinks.svelte
+++ b/src/lib/components/molecules/NavLinks.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	const links = [
+		{ href: '#collections', label: 'Collections' },
+		{ href: '#craft', label: 'The Craft' },
+		{ href: '#manifesto', label: 'Manifesto' },
+		{ href: '#stockists', label: 'Stockists' }
+	] as const;
+</script>
+
+<div class="flex justify-center gap-[34px] max-[880px]:hidden">
+	{#each links as link (link.href)}
+		<a
+			href={link.href}
+			class="text-[11px] font-normal tracking-[0.14em] text-text-secondary uppercase
+			       transition-colors duration-250 hover:text-amber"
+		>
+			{link.label}
+		</a>
+	{/each}
+</div>

--- a/src/lib/components/molecules/NavLogo.svelte
+++ b/src/lib/components/molecules/NavLogo.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import NavMark from '../atoms/NavMark.svelte';
+	import Wordmark from '../atoms/Wordmark.svelte';
+</script>
+
+<div class="flex items-center gap-2.5">
+	<NavMark />
+	<Wordmark />
+</div>

--- a/src/lib/components/organisms/Nav.svelte
+++ b/src/lib/components/organisms/Nav.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import SmallCaps from '../atoms/SmallCaps.svelte';
+	import NavLogo from '../molecules/NavLogo.svelte';
+	import NavLinks from '../molecules/NavLinks.svelte';
+
+	let scrolled = $state(false);
+
+	$effect(() => {
+		const onScroll = () => {
+			scrolled = window.scrollY > 32;
+		};
+		onScroll();
+		window.addEventListener('scroll', onScroll, { passive: true });
+		return () => window.removeEventListener('scroll', onScroll);
+	});
+</script>
+
+<nav
+	class="nav fixed inset-x-0 top-0 z-50 grid grid-cols-[1fr_auto_1fr] items-center
+	       border-b-[0.5px] px-9 transition-all duration-350 ease-in-out"
+	class:condensed={scrolled}
+>
+	<NavLogo />
+	<NavLinks />
+	<div class="flex items-center justify-end gap-[18px]">
+		<span class="text-text-tertiary">
+			<SmallCaps>Est. 2024</SmallCaps>
+		</span>
+		<a
+			href="#stockists"
+			class="inline-flex items-center gap-2 rounded-full border-[0.5px] border-hairline
+			       bg-transparent px-[18px] py-3 font-sans text-[11px] font-medium tracking-[0.2em]
+			       text-text-primary uppercase transition-all duration-250 ease-out
+			       hover:border-amber hover:text-amber"
+		>
+			Find a stockist
+		</a>
+	</div>
+</nav>
+
+<style>
+	.nav {
+		padding-top: 22px;
+		padding-bottom: 22px;
+		background-color: transparent;
+		border-bottom-color: transparent;
+	}
+
+	.condensed {
+		padding-top: 12px;
+		padding-bottom: 12px;
+		background-color: var(--color-nav-bg-condensed);
+		backdrop-filter: blur(18px) saturate(160%);
+		-webkit-backdrop-filter: blur(18px) saturate(160%);
+		border-bottom-color: var(--color-hairline);
+	}
+</style>


### PR DESCRIPTION
## Summary

Closes #5

Implements the Nav organism and its constituent molecules as specified in issue #5.

- **NavLogo molecule** (`src/lib/components/molecules/NavLogo.svelte`) — composes NavMark + Wordmark atoms as the logo unit
- **NavLinks molecule** (`src/lib/components/molecules/NavLinks.svelte`) — anchor links to Collections, The Craft, Manifesto, and Stockists sections; hidden below 880px
- **Nav organism** (`src/lib/components/organisms/Nav.svelte`) — composes NavLogo, NavLinks, and a CTA area (Est. 2024 + Find a stockist ghost link). Tracks `scrolled` state via `$state` with a scroll event listener; condenses the nav with backdrop blur, reduced padding, and border when scrolled past 32px

## Acceptance criteria

- [x] NavLogo molecule exists and renders Wordmark + NavMark atoms
- [x] NavLinks molecule renders anchor links to all four sections
- [x] Nav organism condenses visually once scrolled past the top
- [x] Scroll state is `$state` local to Nav — no external store
- [x] All four anchor targets match the section IDs used by the organisms
- [x] Svelte 5 runes throughout