### PR TITLE
feat: HeroPlate organism — Variant D (Plate) hero

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -12,4 +12,5 @@ export { default as Wordmark } from './atoms/Wordmark.svelte';
 export { default as NavLogo } from './molecules/NavLogo.svelte';
 export { default as NavLinks } from './molecules/NavLinks.svelte';
 
+export { default as HeroPlate } from './organisms/HeroPlate.svelte';
 export { default as Nav } from './organisms/Nav.svelte';

--- a/src/lib/components/organisms/HeroPlate.svelte
+++ b/src/lib/components/organisms/HeroPlate.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import Bracelet from '../atoms/Bracelet.svelte';
+	import Button from '../atoms/Button.svelte';
+	import Eyebrow from '../atoms/Eyebrow.svelte';
+	import PhotoCorner from '../atoms/PhotoCorner.svelte';
+	import PhotoTag from '../atoms/PhotoTag.svelte';
+	import { collections } from '$lib/data/collections';
+
+	const rose = collections[3];
+	const braceletColors = rose.products[0].colors;
+</script>
+
+<section class="hero-plate relative pt-24 pb-[90px]">
+	<div
+		class="mx-auto grid max-w-[1280px] grid-cols-1 items-stretch gap-0 px-9
+		       md:[min-height:88vh] md:grid-cols-2"
+	>
+		<div
+			class="flex flex-col justify-center gap-6 py-20 pr-0
+			       md:border-r md:border-hairline md:pr-[60px]"
+		>
+			<Eyebrow>Spring Collection — MMXXIV</Eyebrow>
+			<h1
+				class="m-0 font-display text-[clamp(56px,6.5vw,96px)] leading-[1.0]
+				       font-light tracking-[0.005em]"
+			>
+				Loomed with <em class="text-amber italic">intention</em>, worn without ceremony.
+			</h1>
+			<p
+				class="m-0 max-w-[440px] font-display text-[20px] leading-[1.5] text-text-secondary italic"
+			>
+				Four collections, twelve bracelets, one quiet idea: that fifty cents of elastic deserves the
+				same care as anything else on the wrist.
+			</p>
+			<div class="mt-4 flex gap-3">
+				<a href="#collections">
+					<Button variant="primary">Browse collections</Button>
+				</a>
+			</div>
+		</div>
+
+		<div class="grid grid-rows-[1fr_auto] gap-6 py-20 pl-0 md:pl-[60px]">
+			<div
+				class="photo-stripes relative min-h-[380px] overflow-hidden rounded-[4px]
+				       border-[0.5px] border-hairline bg-rose-bg"
+			>
+				<PhotoCorner>Plate I</PhotoCorner>
+				<div class="absolute inset-0 flex items-center justify-center p-8">
+					<Bracelet colors={braceletColors} rotation={-6} />
+				</div>
+				<PhotoTag>// hand portrait — wrist 03 / atelier light</PhotoTag>
+			</div>
+			<div
+				class="flex items-baseline justify-between font-mono text-[10px]
+				       tracking-[0.08em] text-text-tertiary"
+			>
+				<span>Photographed in natural light</span>
+				<span>New Hamburg, 04.MMXXIV</span>
+			</div>
+		</div>
+	</div>
+</section>
+
+<style>
+	.photo-stripes {
+		background:
+			repeating-linear-gradient(135deg, var(--color-hairline-soft) 0 1px, transparent 1px 14px),
+			var(--color-rose-bg);
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,9 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+	import { HeroPlate, Nav } from '$lib/components';
+</script>
+
+<Nav />
+
+<main class="flex flex-col">
+	<HeroPlate />
+</main>


### PR DESCRIPTION
## Summary

- Implements the HeroPlate organism at `src/lib/components/organisms/HeroPlate.svelte` as the sole hero variant (Variant D / Plate) carried forward from the source comp
- Uses the Bracelet atom for the hero illustration with Rosé Pivoine colors, PhotoCorner, PhotoTag, Eyebrow, and Button atoms
- Matches the Variant D split editorial layout with photo zone at high visual fidelity — two-column grid, border-right hairline divider, photo-stripes background pattern
- Wires HeroPlate into the landing page (`+page.svelte`)
- No traces of Variants A, B, or C
- Svelte 5 runes throughout, semantic Tailwind tokens only

Closes #6