### PR TITLE
feat: Collections section (issue #7)

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -9,8 +9,11 @@ export { default as SmallCaps } from './atoms/SmallCaps.svelte';
 export { default as Swatch } from './atoms/Swatch.svelte';
 export { default as Wordmark } from './atoms/Wordmark.svelte';
 
-export { default as NavLogo } from './molecules/NavLogo.svelte';
+export { default as CollectionTab } from './molecules/CollectionTab.svelte';
 export { default as NavLinks } from './molecules/NavLinks.svelte';
+export { default as NavLogo } from './molecules/NavLogo.svelte';
+export { default as ProductCard } from './molecules/ProductCard.svelte';
 
+export { default as Collections } from './organisms/Collections.svelte';
 export { default as HeroPlate } from './organisms/HeroPlate.svelte';
 export { default as Nav } from './organisms/Nav.svelte';

--- a/src/lib/components/molecules/CollectionTab.svelte
+++ b/src/lib/components/molecules/CollectionTab.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import type { Collection } from '$lib/data/collections';
+	import Swatch from '../atoms/Swatch.svelte';
+
+	let {
+		collection,
+		active = false,
+		onclick,
+		onmouseenter,
+		onmouseleave
+	}: {
+		collection: Collection;
+		active?: boolean;
+		onclick?: () => void;
+		onmouseenter?: () => void;
+		onmouseleave?: () => void;
+	} = $props();
+
+	let index = $derived(
+		collection.id === 'soleil'
+			? 1
+			: collection.id === 'foret'
+				? 2
+				: collection.id === 'crepuscule'
+					? 3
+					: 4
+	);
+</script>
+
+<button
+	role="tab"
+	aria-selected={active}
+	class="font-inherit flex flex-1 flex-col items-center gap-2 border-0 border-b-[1px]
+	       bg-transparent px-3 py-[18px] transition-[color,border-color] duration-250
+	       {active ? 'border-b-amber text-text-primary' : 'border-b-transparent text-text-secondary'}
+	       max-[880px]:[flex:0_0_auto]"
+	{onclick}
+	{onmouseenter}
+	{onmouseleave}
+>
+	<Swatch color={collection.color} />
+	<span class="font-display text-[22px] font-light tracking-[0.01em] italic">{collection.name}</span
+	>
+	<span
+		class="text-[9px] font-medium tracking-[0.22em] uppercase
+		       {active ? 'text-amber' : 'text-text-tertiary'}"
+	>
+		№ 0{index} · {collection.products.length} pieces
+	</span>
+</button>

--- a/src/lib/components/molecules/ProductCard.svelte
+++ b/src/lib/components/molecules/ProductCard.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { Product, Collection } from '$lib/data/collections';
+	import Bracelet from '../atoms/Bracelet.svelte';
+
+	let {
+		product,
+		collection,
+		index = 0
+	}: {
+		product: Product;
+		collection: Collection;
+		index?: number;
+	} = $props();
+
+	let rotation = $derived(-8 + (index - 1) * 4);
+</script>
+
+<article
+	class="flex flex-col overflow-hidden rounded-[6px] border-[0.5px] border-hairline
+	       bg-surface transition-[border-color,transform,box-shadow] duration-300
+	       hover:-translate-y-[2px] hover:border-amber"
+>
+	<div
+		class="relative flex aspect-[5/4] items-center justify-center"
+		style:background-color={collection.bg}
+	>
+		<div class="w-[78%]">
+			<Bracelet colors={product.colors} {rotation} />
+		</div>
+	</div>
+	<div class="flex flex-col gap-1.5 border-t-[0.5px] border-hairline-soft px-5 py-[18px] pb-5">
+		<span class="text-[9px] font-medium tracking-[0.22em] text-amber uppercase"
+			>{collection.name}</span
+		>
+		<span class="font-display text-[18px] font-normal tracking-[0.01em]">{product.name}</span>
+		<div class="mt-1.5 flex items-center justify-between">
+			<span class="text-[12px] font-medium tracking-[0.04em]">{product.price}</span>
+			<button
+				class="rounded-full border-[0.5px] border-hairline bg-transparent px-3 py-[7px]
+				       font-sans text-[9px] font-medium tracking-[0.2em] text-text-secondary uppercase
+				       transition-all duration-250 hover:border-amber hover:text-amber"
+			>
+				View
+			</button>
+		</div>
+	</div>
+</article>

--- a/src/lib/components/organisms/Collections.svelte
+++ b/src/lib/components/organisms/Collections.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { collections } from '$lib/data/collections';
+	import Eyebrow from '../atoms/Eyebrow.svelte';
+	import CollectionTab from '../molecules/CollectionTab.svelte';
+	import ProductCard from '../molecules/ProductCard.svelte';
+
+	let active: string = $state(collections[0].id);
+
+	let col = $derived(collections.find((c) => c.id === active) ?? collections[0]);
+</script>
+
+<section id="collections" class="py-[120px] pb-[140px]">
+	<div class="mx-auto max-w-[1280px] px-9">
+		<div class="mb-16">
+			<Eyebrow>The Four Collections</Eyebrow>
+			<h2
+				class="m-0 mt-4 font-display text-[clamp(36px,4vw,52px)] leading-[1.05]
+				       font-light tracking-[0.005em]"
+			>
+				An atlas of <em class="text-amber italic">color</em>.
+			</h2>
+			<p
+				class="m-0 mt-3 max-w-[52ch] font-sans text-[15px] leading-[1.6] font-light text-text-secondary"
+			>
+				Each collection is named for an hour of the day, or a feeling we couldn't otherwise place.
+			</p>
+		</div>
+
+		<div
+			class="mx-auto my-14 flex max-w-[980px] justify-center border-t-[0.5px] border-b-[0.5px]
+			       border-hairline"
+			role="tablist"
+		>
+			{#each collections as c, i (c.id)}
+				<div class={i > 0 ? 'border-l-[0.5px] border-hairline' : ''}>
+					<CollectionTab collection={c} active={c.id === active} onclick={() => (active = c.id)} />
+				</div>
+			{/each}
+		</div>
+
+		<div class="grid grid-cols-3 items-stretch gap-[14px] max-[880px]:grid-cols-1">
+			{#each col.products as product, i (product.name)}
+				<ProductCard {product} collection={col} index={i} />
+			{/each}
+		</div>
+	</div>
+</section>


### PR DESCRIPTION
## Summary

- Implements **CollectionTab** molecule — tab button with active/inactive state, swatch, and collection metadata
- Implements **ProductCard** molecule — product card rendering Bracelet in the collection's three hex colors with hover animation
- Implements **Collections** organism — four tabs (Soleil, Forêt, Crépuscule, Rosé) with three product cards each, tab switching via local `$state`
- Updates barrel export in `index.ts`

Closes #7

## Acceptance criteria

- [x] CollectionTab molecule exists and reflects active/inactive state
- [x] ProductCard molecule renders Bracelet in the product's collection colors
- [x] Collections organism renders tabs for all four collections
- [x] Each collection displays three product cards
- [x] Switching tabs updates the displayed cards — local `$state`, no store
- [x] Data is consumed from `src/lib/data/collections.ts`
- [x] Svelte 5 runes throughout