### PR TITLE
feat: Craft + Manifesto sections

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -14,6 +14,11 @@ export { default as NavLinks } from './molecules/NavLinks.svelte';
 export { default as NavLogo } from './molecules/NavLogo.svelte';
 export { default as ProductCard } from './molecules/ProductCard.svelte';
 
+export { default as CraftItem } from './molecules/CraftItem.svelte';
+export { default as ManifestoSignature } from './molecules/ManifestoSignature.svelte';
+
 export { default as Collections } from './organisms/Collections.svelte';
+export { default as Craft } from './organisms/Craft.svelte';
 export { default as HeroPlate } from './organisms/HeroPlate.svelte';
+export { default as Manifesto } from './organisms/Manifesto.svelte';
 export { default as Nav } from './organisms/Nav.svelte';

--- a/src/lib/components/molecules/CraftItem.svelte
+++ b/src/lib/components/molecules/CraftItem.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { HexColor } from '$lib/data/collections';
+
+	let {
+		numeral,
+		title,
+		description,
+		iconColor,
+		iconBg
+	}: {
+		numeral: string;
+		title: string;
+		description: string;
+		iconColor: HexColor;
+		iconBg: string;
+	} = $props();
+</script>
+
+<div class="grid grid-cols-[48px_1fr] items-start gap-5">
+	<div
+		class="flex h-9 w-9 items-center justify-center rounded-full font-display
+		       text-[16px] italic"
+		style:background={iconBg}
+		style:color={iconColor}
+	>
+		{numeral}
+	</div>
+	<div>
+		<h4 class="m-0 font-display text-[20px] font-normal tracking-[0.005em]">
+			{title}
+		</h4>
+		<p
+			class="m-0 max-w-[38ch] font-sans text-[13.5px] leading-[1.7] font-light text-text-secondary"
+		>
+			{description}
+		</p>
+	</div>
+</div>

--- a/src/lib/components/molecules/ManifestoSignature.svelte
+++ b/src/lib/components/molecules/ManifestoSignature.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<div class="mt-14 inline-flex flex-col items-center gap-1.5 text-manifesto-text/55">
+	<span class="font-display text-[24px] text-manifesto-accent italic"> — & — </span>
+	<span class="font-sans text-[10px] font-medium tracking-[0.22em] uppercase">
+		{@render children()}
+	</span>
+</div>

--- a/src/lib/components/organisms/Craft.svelte
+++ b/src/lib/components/organisms/Craft.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import Eyebrow from '../atoms/Eyebrow.svelte';
+	import PhotoCorner from '../atoms/PhotoCorner.svelte';
+	import PhotoTag from '../atoms/PhotoTag.svelte';
+	import CraftItem from '../molecules/CraftItem.svelte';
+</script>
+
+<section id="craft" class="border-t border-b border-hairline bg-off-white py-[130px]">
+	<div class="mx-auto max-w-[1280px] px-9">
+		<div class="flex flex-col items-center gap-3.5 text-center">
+			<Eyebrow>The Craft</Eyebrow>
+			<h2 class="sec-title">
+				A loom, a palette, <em>a point of view</em>.
+			</h2>
+			<p class="sec-sub">
+				Forty-three colors of elastic, sorted by hour of day, strung by hand on a pegboard the size
+				of a postcard.
+			</p>
+		</div>
+
+		<div class="mt-[72px] grid grid-cols-1 items-center gap-[80px] md:grid-cols-2">
+			<div
+				class="photo-stripes relative aspect-[4/5] overflow-hidden rounded-[4px] border-[0.5px] border-hairline bg-foret-bg"
+			>
+				<PhotoCorner>Plate II</PhotoCorner>
+				<PhotoTag>// atelier still life — pegboard, 2026</PhotoTag>
+			</div>
+			<div class="flex flex-col gap-9">
+				<CraftItem
+					numeral="i."
+					title="The palette is curated, never assembled."
+					description="Each collection begins with a single colour observed in the world — the inside of an apricot, a sage hedge after rain — and the rest are chosen to keep it company."
+					iconColor="#C17B3A"
+					iconBg="rgba(193,123,58,0.14)"
+				/>
+				<CraftItem
+					numeral="ii."
+					title="Strung by hand, on a pegboard."
+					description="The loom is a wooden board, the size of a postcard, with twenty-eight pins. Each bracelet takes between four and seven minutes to weave."
+					iconColor="#4A8B7A"
+					iconBg="rgba(74,139,122,0.14)"
+				/>
+				<CraftItem
+					numeral="iii."
+					title="The price is fifty cents."
+					description="It is the price of the materials, plus a small consideration for the time. We do not feel the need to say more about it."
+					iconColor="#7B6AAF"
+					iconBg="rgba(123,106,175,0.14)"
+				/>
+			</div>
+		</div>
+	</div>
+</section>
+
+<style>
+	.photo-stripes {
+		background:
+			repeating-linear-gradient(135deg, var(--color-hairline-soft) 0 1px, transparent 1px 14px),
+			var(--color-foret-bg);
+	}
+
+	.sec-title {
+		font-family: var(--font-display);
+		font-weight: 300;
+		font-size: 54px;
+		line-height: 1.05;
+		letter-spacing: 0.005em;
+		margin: 0;
+	}
+
+	.sec-title em {
+		font-style: italic;
+		font-weight: 300;
+	}
+
+	.sec-sub {
+		font-family: var(--font-display);
+		font-style: italic;
+		font-weight: 300;
+		font-size: 18px;
+		color: var(--color-text-secondary);
+		margin: 0;
+		max-width: 520px;
+	}
+</style>

--- a/src/lib/components/organisms/Manifesto.svelte
+++ b/src/lib/components/organisms/Manifesto.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import ManifestoSignature from '../molecules/ManifestoSignature.svelte';
+</script>
+
+<section id="manifesto" class="bg-manifesto-bg py-[160px] text-center text-manifesto-text">
+	<div class="mx-auto max-w-[1280px] px-9">
+		<span
+			class="font-sans text-[9.5px] font-medium tracking-[0.28em] text-manifesto-accent uppercase"
+		>
+			Manifesto
+		</span>
+		<h2
+			class="mx-auto mt-8 max-w-[18ch] font-display text-[clamp(40px,5vw,68px)]
+			       leading-[1.18] font-light tracking-[0.005em]"
+		>
+			We believe a wrist is a small canvas, and a small canvas deserves
+			<em class="text-manifesto-accent italic">real attention</em>.
+		</h2>
+		<ManifestoSignature>The Atelier of Hue & Weave</ManifestoSignature>
+	</div>
+</section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-	import { HeroPlate, Nav } from '$lib/components';
+	import { Craft, HeroPlate, Manifesto, Nav } from '$lib/components';
 </script>
 
 <Nav />
 
 <main class="flex flex-col">
 	<HeroPlate />
+	<Craft />
+	<Manifesto />
 </main>


### PR DESCRIPTION
## Summary

- Implement Craft and Manifesto organisms and their molecules per issue #8
- `CraftItem` molecule — numbered icon + title + description, styled to match `landing.html`
- `Craft` organism — two-column layout with photo placeholder and 3 craft items, section id `#craft`
- `ManifestoSignature` molecule — decorative "— & —" mark with atelier label
- `Manifesto` organism — dark-background section with manifesto text and signature, section id `#manifesto`
- Both sections wired into `+page.svelte`
- All components use Svelte 5 runes, semantic Tailwind tokens, no raw hex in markup

Closes #8