### PR TITLE
feat: Stockists section + WorldMap (closes #9)

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -16,9 +16,12 @@ export { default as ProductCard } from './molecules/ProductCard.svelte';
 
 export { default as CraftItem } from './molecules/CraftItem.svelte';
 export { default as ManifestoSignature } from './molecules/ManifestoSignature.svelte';
+export { default as StockistRow } from './molecules/StockistRow.svelte';
+export { default as WorldMap } from './molecules/WorldMap.svelte';
 
 export { default as Collections } from './organisms/Collections.svelte';
 export { default as Craft } from './organisms/Craft.svelte';
 export { default as HeroPlate } from './organisms/HeroPlate.svelte';
 export { default as Manifesto } from './organisms/Manifesto.svelte';
 export { default as Nav } from './organisms/Nav.svelte';
+export { default as Stockists } from './organisms/Stockists.svelte';

--- a/src/lib/components/molecules/StockistRow.svelte
+++ b/src/lib/components/molecules/StockistRow.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import type { Stockist } from '$lib/data/stockists';
+
+	let {
+		stockist,
+		isHighlighted = false,
+		onmouseenter,
+		onmouseleave
+	}: {
+		stockist: Stockist;
+		isHighlighted?: boolean;
+		onmouseenter?: () => void;
+		onmouseleave?: () => void;
+	} = $props();
+
+	let sold = $derived(stockist.status === 'sold-out');
+</script>
+
+<div
+	role="listitem"
+	class="grid grid-cols-[auto_1fr_auto] items-baseline gap-[18px] border-b-[0.5px]
+	       border-hairline-soft py-[18px] transition-[color,opacity] duration-250
+	       first:border-t-[0.5px] first:border-hairline-soft"
+	style:color={isHighlighted ? 'var(--color-amber)' : undefined}
+	style:opacity={sold ? 0.6 : 1}
+	{onmouseenter}
+	{onmouseleave}
+>
+	<span
+		class="font-display text-[20px] font-light italic"
+		style:text-decoration={sold ? 'line-through' : 'none'}
+		style:text-decoration-color="var(--color-hairline)"
+	>
+		{stockist.city}
+	</span>
+	<span class="font-sans text-[13px] font-light text-text-secondary">{stockist.place}</span>
+	<span
+		class="font-sans text-[9px] font-medium tracking-[0.22em] uppercase"
+		style:color={sold ? 'var(--color-text-tertiary)' : 'var(--color-amber)'}
+	>
+		{sold ? 'Sold out' : 'In stock'}
+	</span>
+</div>

--- a/src/lib/components/molecules/WorldMap.svelte
+++ b/src/lib/components/molecules/WorldMap.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import type { Stockist } from '$lib/data/stockists';
+
+	let {
+		stockists,
+		highlightedIndex = null,
+		onpinenter,
+		onpinleave
+	}: {
+		stockists: readonly Stockist[];
+		highlightedIndex?: number | null;
+		onpinenter?: (index: number) => void;
+		onpinleave?: () => void;
+	} = $props();
+
+	let hLines = $derived(Array.from({ length: 11 }, (_, i) => i));
+	let vLines = $derived(Array.from({ length: 13 }, (_, i) => i));
+</script>
+
+<svg
+	viewBox="0 0 1000 540"
+	class="h-auto w-full rounded-[4px] border-[0.5px] border-hairline bg-surface p-6"
+	aria-hidden="true"
+>
+	<g stroke="var(--color-hairline-soft)" stroke-width="0.4">
+		{#each hLines as i (i)}
+			<line x1="0" x2="1000" y1={i * 54} y2={i * 54} />
+		{/each}
+		{#each vLines as i (i)}
+			<line x1={i * 83} x2={i * 83} y1="0" y2="540" />
+		{/each}
+	</g>
+
+	<g fill="var(--color-hairline-soft)">
+		<path
+			d="M120,180 Q170,140 240,150 Q300,160 320,210 Q310,260 260,280 Q200,290 160,270 Q110,250 120,180 Z"
+		/>
+		<path
+			d="M430,150 Q500,130 560,150 Q610,170 620,210 Q610,260 560,280 Q480,300 440,270 Q400,230 430,150 Z"
+		/>
+		<path d="M780,200 Q860,180 900,220 Q920,260 880,290 Q820,310 780,290 Q740,260 780,200 Z" />
+		<path d="M820,440 Q880,430 900,460 Q900,490 860,500 Q820,500 810,470 Q810,450 820,440 Z" />
+		<path d="M520,360 Q560,350 580,380 Q580,410 540,420 Q500,420 510,390 Q510,370 520,360 Z" />
+	</g>
+
+	{#each stockists as s, i (s.city)}
+		{@const sold = s.status === 'sold-out'}
+		{@const pinFill = sold ? '#8E887C' : '#C17B3A'}
+		<g
+			role="button"
+			tabindex="-1"
+			style:cursor="default"
+			onmouseenter={() => onpinenter?.(i)}
+			onmouseleave={() => onpinleave?.()}
+		>
+			<circle
+				cx={s.x}
+				cy={s.y}
+				r={highlightedIndex === i ? 18 : 14}
+				fill={pinFill}
+				opacity={sold ? 0.1 : 0.14}
+			/>
+			<circle cx={s.x} cy={s.y} r="4.5" fill={pinFill} opacity={sold ? 0.55 : 1} />
+			<text
+				x={s.x + 12}
+				y={s.y + 4}
+				font-size="11"
+				font-family="DM Sans"
+				font-weight="500"
+				letter-spacing="0.14em"
+				fill={sold ? 'var(--color-text-tertiary)' : 'var(--color-text-primary)'}
+			>
+				{s.city.toUpperCase()}
+			</text>
+		</g>
+	{/each}
+</svg>

--- a/src/lib/components/organisms/Stockists.svelte
+++ b/src/lib/components/organisms/Stockists.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { stockists } from '$lib/data/stockists';
+	import Eyebrow from '../atoms/Eyebrow.svelte';
+	import StockistRow from '../molecules/StockistRow.svelte';
+	import WorldMap from '../molecules/WorldMap.svelte';
+
+	let hoveredIndex: number | null = $state(null);
+</script>
+
+<section id="stockists" class="py-[120px] pb-[130px]">
+	<div class="mx-auto max-w-[1280px] px-9">
+		<div class="flex flex-col items-center gap-3.5 text-center">
+			<Eyebrow>Stockists</Eyebrow>
+			<h2 class="sec-title">Found in seven <em>cities</em>.</h2>
+			<p class="sec-sub">We do not sell online. We prefer the bracelet to be held first.</p>
+		</div>
+
+		<div class="mt-16 grid grid-cols-1 items-center gap-[60px] md:grid-cols-[1.2fr_1fr]">
+			<WorldMap
+				{stockists}
+				highlightedIndex={hoveredIndex}
+				onpinenter={(i) => (hoveredIndex = i)}
+				onpinleave={() => (hoveredIndex = null)}
+			/>
+
+			<div class="flex flex-col">
+				{#each stockists as s, i (s.city)}
+					<StockistRow
+						stockist={s}
+						isHighlighted={hoveredIndex === i}
+						onmouseenter={() => (hoveredIndex = i)}
+						onmouseleave={() => (hoveredIndex = null)}
+					/>
+				{/each}
+			</div>
+		</div>
+	</div>
+</section>
+
+<style>
+	.sec-title {
+		font-family: var(--font-display);
+		font-weight: 300;
+		font-size: 54px;
+		line-height: 1.05;
+		letter-spacing: 0.005em;
+		margin: 0;
+	}
+
+	.sec-title em {
+		font-style: italic;
+		font-weight: 300;
+		color: var(--color-amber);
+	}
+
+	.sec-sub {
+		font-family: var(--font-display);
+		font-style: italic;
+		font-weight: 300;
+		font-size: 18px;
+		color: var(--color-text-secondary);
+		margin: 0;
+		max-width: 520px;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Craft, HeroPlate, Manifesto, Nav } from '$lib/components';
+	import { Craft, HeroPlate, Manifesto, Nav, Stockists } from '$lib/components';
 </script>
 
 <Nav />
@@ -8,4 +8,5 @@
 	<HeroPlate />
 	<Craft />
 	<Manifesto />
+	<Stockists />
 </main>


### PR DESCRIPTION
## Summary

- Implements the Stockists organism and its molecules as specified in #9
- `StockistRow.svelte` — renders a single stockist row with city name, place, and in-stock/sold-out status; highlights when `isHighlighted` is true
- `WorldMap.svelte` — renders the abstract continent blobs, hairline lat/lon grid, and data-driven map pins with in-stock vs sold-out styling; accepts `highlightedIndex` to drive pin highlight state
- `Stockists.svelte` — composes StockistRow list and WorldMap; owns `hoveredIndex` as local `$state` so hovering a map pin highlights the corresponding row and vice versa
- All data consumed from `src/lib/data/stockists.ts` — adding a stockist requires only a data edit
- Svelte 5 runes throughout (`$props`, `$state`, `$derived`)

## Acceptance criteria

- [x] StockistRow molecule renders city name and in-stock/sold-out state
- [x] WorldMap molecule renders all seven pins with correct in-stock/sold-out styling
- [x] Hovering a map pin highlights the corresponding stockist row
- [x] Hovering a stockist row highlights the corresponding map pin
- [x] Cross-highlight state is `$state` local to the Stockists organism — no store
- [x] All data consumed from `src/lib/data/stockists.ts` — no hardcoded markup for individual cities
- [x] Svelte 5 runes throughout

Closes #9