### PR TITLE
feat: Announce + Footer organisms and AnnounceTrack molecule

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -9,6 +9,7 @@ export { default as SmallCaps } from './atoms/SmallCaps.svelte';
 export { default as Swatch } from './atoms/Swatch.svelte';
 export { default as Wordmark } from './atoms/Wordmark.svelte';
 
+export { default as AnnounceTrack } from './molecules/AnnounceTrack.svelte';
 export { default as CollectionTab } from './molecules/CollectionTab.svelte';
 export { default as NavLinks } from './molecules/NavLinks.svelte';
 export { default as NavLogo } from './molecules/NavLogo.svelte';
@@ -19,8 +20,10 @@ export { default as ManifestoSignature } from './molecules/ManifestoSignature.sv
 export { default as StockistRow } from './molecules/StockistRow.svelte';
 export { default as WorldMap } from './molecules/WorldMap.svelte';
 
+export { default as Announce } from './organisms/Announce.svelte';
 export { default as Collections } from './organisms/Collections.svelte';
 export { default as Craft } from './organisms/Craft.svelte';
+export { default as Footer } from './organisms/Footer.svelte';
 export { default as HeroPlate } from './organisms/HeroPlate.svelte';
 export { default as Manifesto } from './organisms/Manifesto.svelte';
 export { default as Nav } from './organisms/Nav.svelte';

--- a/src/lib/components/molecules/AnnounceTrack.svelte
+++ b/src/lib/components/molecules/AnnounceTrack.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	let { items = [] }: { items?: string[] } = $props();
+</script>
+
+<div
+	class="flex items-center justify-center gap-7 font-sans text-[10px] font-medium tracking-[0.18em] text-announce-text uppercase"
+>
+	{#each items as item, i (item)}
+		<span>{item}</span>
+		{#if i < items.length - 1}
+			<span class="h-[3px] w-[3px] shrink-0 rounded-full bg-announce-text/55"></span>
+		{/if}
+	{/each}
+</div>

--- a/src/lib/components/organisms/Announce.svelte
+++ b/src/lib/components/organisms/Announce.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import AnnounceTrack from '../molecules/AnnounceTrack.svelte';
+
+	const items = [
+		'New · The Crépuscule Collection',
+		'Now stocked in 7 cities',
+		'Hand-loomed in New Hamburg',
+		'$0.50 — and not a cent less'
+	];
+</script>
+
+<div class="overflow-hidden bg-announce-bg py-[14px] text-announce-text">
+	<AnnounceTrack {items} />
+</div>

--- a/src/lib/components/organisms/Footer.svelte
+++ b/src/lib/components/organisms/Footer.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import Eyebrow from '../atoms/Eyebrow.svelte';
+	import Hairline from '../atoms/Hairline.svelte';
+	import Wordmark from '../atoms/Wordmark.svelte';
+
+	type FooterLink = { label: string; href?: string };
+
+	type FooterColumn = { heading: string; links: FooterLink[] };
+
+	const columns: FooterColumn[] = [
+		{
+			heading: 'Collections',
+			links: [
+				{ label: 'Soleil', href: '#collections' },
+				{ label: 'Forêt', href: '#collections' },
+				{ label: 'Crépuscule', href: '#collections' },
+				{ label: 'Rosé', href: '#collections' }
+			]
+		},
+		{
+			heading: 'The Atelier',
+			links: [
+				{ label: 'The Craft', href: '#craft' },
+				{ label: 'Manifesto', href: '#manifesto' },
+				{ label: 'Stockists', href: '#stockists' },
+				{ label: 'Press inquiries' }
+			]
+		},
+		{
+			heading: 'Atelier',
+			links: [{ label: 'bonjour@hueandweave.com' }]
+		}
+	];
+</script>
+
+<footer class="transition-background bg-bg px-9 pt-20 pb-10 duration-350 ease-in-out">
+	<Hairline position="top" />
+
+	<div class="mx-auto max-w-[1200px]">
+		<div
+			class="grid grid-cols-[1.4fr_1fr_1fr_1fr] gap-16 pb-16 max-[880px]:grid-cols-2 max-[880px]:gap-9"
+		>
+			<div>
+				<Wordmark size="lg" />
+				<p
+					class="mt-2 max-w-[30ch] font-display text-[15px] leading-[1.55] font-light text-text-secondary italic"
+				>
+					Color is the craft.
+				</p>
+			</div>
+
+			{#each columns as col (col.heading)}
+				<div>
+					<Eyebrow>{col.heading}</Eyebrow>
+					<ul class="m-0 flex list-none flex-col gap-2.5 p-0">
+						{#each col.links as link (link.label)}
+							<li class="text-[13px] font-light text-text-secondary">
+								{#if link.href}
+									<a href={link.href} class="transition-colors duration-200 hover:text-amber">
+										{link.label}
+									</a>
+								{:else}
+									{link.label}
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/each}
+		</div>
+
+		<Hairline />
+
+		<div
+			class="flex items-center justify-between pt-8 font-sans text-[10.5px] font-medium tracking-[0.16em] text-text-tertiary uppercase"
+		>
+			<span>&copy; MMXXIV Hue &amp; Weave</span>
+			<span>Hand-loomed &middot; New Hamburg &middot; Est. 2024</span>
+		</div>
+	</div>
+</footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-	import { Craft, HeroPlate, Manifesto, Nav, Stockists } from '$lib/components';
+	import { Announce, Craft, Footer, HeroPlate, Manifesto, Nav, Stockists } from '$lib/components';
 </script>
 
 <Nav />
+
+<Announce />
 
 <main class="flex flex-col">
 	<HeroPlate />
@@ -10,3 +12,5 @@
 	<Manifesto />
 	<Stockists />
 </main>
+
+<Footer />


### PR DESCRIPTION
## Summary

- Implement `AnnounceTrack` molecule — scrolling announcement track with dot separators between items, accepting an `items` string array prop
- Implement `Announce` organism — announcement banner bar composed from AnnounceTrack, using `announce-bg`/`announce-text` semantic tokens
- Implement `Footer` organism — page footer with 4-column grid (brand + 3 link columns), Wordmark, Eyebrow headings, Hairline dividers, and bottom bar with copyright/tagline; responsive at 880px breakpoint
- Wire both into `+page.svelte` and export from barrel `index.ts`

Closes #10