### PR TITLE
feat: LandingTemplate + root route + responsive 880px layout

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -28,3 +28,5 @@ export { default as HeroPlate } from './organisms/HeroPlate.svelte';
 export { default as Manifesto } from './organisms/Manifesto.svelte';
 export { default as Nav } from './organisms/Nav.svelte';
 export { default as Stockists } from './organisms/Stockists.svelte';
+
+export { default as LandingTemplate } from './templates/LandingTemplate.svelte';

--- a/src/lib/components/organisms/HeroPlate.svelte
+++ b/src/lib/components/organisms/HeroPlate.svelte
@@ -12,12 +12,12 @@
 
 <section class="hero-plate relative pt-24 pb-[90px]">
 	<div
-		class="mx-auto grid max-w-[1280px] grid-cols-1 items-stretch gap-0 px-9
-		       md:[min-height:88vh] md:grid-cols-2"
+		class="mx-auto grid max-w-[1280px] grid-cols-2 items-stretch gap-0 px-9
+		       max-[880px]:grid-cols-1 min-[881px]:min-h-[88vh]"
 	>
 		<div
 			class="flex flex-col justify-center gap-6 py-20 pr-0
-			       md:border-r md:border-hairline md:pr-[60px]"
+			       min-[881px]:border-r min-[881px]:border-hairline min-[881px]:pr-[60px]"
 		>
 			<Eyebrow>Spring Collection — MMXXIV</Eyebrow>
 			<h1
@@ -39,7 +39,7 @@
 			</div>
 		</div>
 
-		<div class="grid grid-rows-[1fr_auto] gap-6 py-20 pl-0 md:pl-[60px]">
+		<div class="grid grid-rows-[1fr_auto] gap-6 py-20 pl-0 min-[881px]:pl-[60px]">
 			<div
 				class="photo-stripes relative min-h-[380px] overflow-hidden rounded-[4px]
 				       border-[0.5px] border-hairline bg-rose-bg"

--- a/src/lib/components/templates/LandingTemplate.svelte
+++ b/src/lib/components/templates/LandingTemplate.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import {
+		Announce,
+		Collections,
+		Craft,
+		Footer,
+		HeroPlate,
+		Manifesto,
+		Nav,
+		Stockists
+	} from '$lib/components';
+</script>
+
+<Announce />
+<Nav />
+
+<main class="flex flex-col">
+	<HeroPlate />
+	<Collections />
+	<Craft />
+	<Manifesto />
+	<Stockists />
+</main>
+
+<Footer />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,16 +1,5 @@
 <script lang="ts">
-	import { Announce, Craft, Footer, HeroPlate, Manifesto, Nav, Stockists } from '$lib/components';
+	import { LandingTemplate } from '$lib/components';
 </script>
 
-<Nav />
-
-<Announce />
-
-<main class="flex flex-col">
-	<HeroPlate />
-	<Craft />
-	<Manifesto />
-	<Stockists />
-</main>
-
-<Footer />
+<LandingTemplate />


### PR DESCRIPTION
## Summary

Closes #11

- **LandingTemplate**: New template at `src/lib/components/templates/LandingTemplate.svelte` composing all eight organisms in the specified order: Announce → Nav → HeroPlate → Collections → Craft → Manifesto → Stockists → Footer
- **Root route**: `+page.svelte` reduced to a thin wrapper rendering LandingTemplate with no other logic
- **Responsive layout**: HeroPlate breakpoint updated from `md:` (768px) to the project's 880px convention (`max-[880px]`/`min-[881px]`), so the hero stacks vertically at ≤880px as required
- **Static prerender**: Added `+layout.ts` with `export const prerender = true` to activate `adapter-static` prerendering for all routes including root

## Acceptance criteria

- [x] LandingTemplate exists under `src/lib/components/templates/` and composes all eight organisms in correct order
- [x] Root route `+page.svelte` renders LandingTemplate and contains no other logic
- [x] Page renders correctly at desktop widths
- [x] Hero stacks vertically at ≤880px; no layout breakage on mobile
- [x] All four anchor targets (Collections, The Craft, Manifesto, Stockists) scroll to the correct sections
- [x] Static prerender confirmed — `+page.svelte` prerendered by adapter-static
- [x] Svelte 5 runes throughout